### PR TITLE
Added $$ parsing

### DIFF
--- a/scripts/frontend.php
+++ b/scripts/frontend.php
@@ -7,15 +7,15 @@ function katex_init() {
 
 	if (is_array($katex_options)) {
 		if (isset($katex_options['katex_jsdelivr_setting']) && $katex_options['katex_jsdelivr_setting'] == 1) {
-			wp_register_style('katex', '//cdn.jsdelivr.net/katex/0.1.0/katex.min.css', false, null);
-			wp_register_script('katex', '//cdn.jsdelivr.net/katex/0.1.0/katex.min.js', false, array('jquery'));
+			wp_register_style('katex', '//cdn.jsdelivr.net/katex/0.1.1/katex.min.css', false, null);
+			wp_register_script('katex', '//cdn.jsdelivr.net/katex/0.1.1/katex.min.js', array('jquery'), null);
 		} else {
-			wp_register_style('katex', plugins_url('assets/katex.min.css', dirname(__FILE__)), false, null);
-			wp_register_script('katex', plugins_url('assets/katex.min.js', dirname(__FILE__)), false, array('jquery'));
+			wp_register_style('katex', plugins_url('assets/katex.min.css', dirname(__FILE__)), false, '0.1.1');
+			wp_register_script('katex', plugins_url('assets/katex.min.js', dirname(__FILE__)), array('jquery'), '0.1.1', true);
 		}
 	} else {
-		wp_register_style('katex', plugins_url('assets/katex.min.css', dirname(__FILE__)), false, null);
-		wp_register_script('katex', plugins_url('assets/katex.min.js', dirname(__FILE__)), false, array('jquery'));
+		wp_register_style('katex', plugins_url('assets/katex.min.css', dirname(__FILE__)), false, '0.1.1');
+		wp_register_script('katex', plugins_url('assets/katex.min.js', dirname(__FILE__)), array('jquery'), '0.1.1', true);
 	}
 }
 add_action('init', 'katex_init');
@@ -32,6 +32,25 @@ function katex_handler($atts, $content = null){
 }
 add_shortcode('latex', 'katex_handler');
 
+add_filter( 'the_content', 'content_parser', 7 );
+
+function content_parser($content)
+{
+	$content = preg_replace_callback('/(!*\$\$(.*?)\$\$)/s','do_doubledollars',$content);
+
+	return $content;
+}
+
+function do_doubledollars($m)
+{
+	$formula_text =	trim($m[2]);
+
+	wp_enqueue_script('katex');
+	wp_enqueue_style('katex');
+	
+	return '<script type="text/katex">' . html_entity_decode($formula_text) . '</script>';
+}
+
 function katex_rubber() {
 	?>
 	<script>
@@ -47,4 +66,5 @@ function katex_rubber() {
 	</script>
 	<?php
 }
+
 add_action('wp_footer', 'katex_rubber', 100);


### PR DESCRIPTION
Added $$ parsing so that one can write things like $$y = sin(x)$$ instead of [latex]y = sin(x)[/latex].

Also, I changed the cdn version for katex to what you had on your plugin page.

Nice work, I'm very happy to have Katex working in WP.
